### PR TITLE
feat(macros): implement internal helper macros

### DIFF
--- a/macros/_internal/_get_config.sql
+++ b/macros/_internal/_get_config.sql
@@ -1,0 +1,24 @@
+{#
+  Internal helper macro to extract configuration from vars.
+
+  Returns a dictionary with database names that can be overridden
+  in the consuming project's dbt_project.yml.
+
+  Returns:
+    dict: {
+      'shop_db': str - E-commerce database name (default: 'jaffle_shop'),
+      'crm_db': str - Marketing/CRM database name (default: 'jaffle_crm')
+    }
+
+  Example usage:
+    {% set cfg = demo_source_ops._get_config() %}
+    {{ log("Using shop database: " ~ cfg.shop_db, info=True) }}
+#}
+
+{% macro _get_config() %}
+  {% set config = var('demo_source_ops', {}) %}
+  {% do return({
+    'shop_db': config.get('shop_db', 'jaffle_shop'),
+    'crm_db': config.get('crm_db', 'jaffle_crm')
+  }) %}
+{% endmacro %}

--- a/macros/_internal/_get_sql.sql
+++ b/macros/_internal/_get_sql.sql
@@ -1,0 +1,51 @@
+{#
+  Internal helper macro to load SQL files with adapter detection.
+
+  Automatically routes to the correct SQL directory based on the current
+  target adapter type (duckdb vs sqlserver).
+
+  Args:
+    path (str): Relative path to SQL file within the adapter directory,
+                without .sql extension. Examples:
+                - 'baseline/shop_schema'
+                - 'deltas/day_01_shop'
+                - 'utilities/truncate_crm'
+
+  Returns:
+    str: Contents of the SQL file
+
+  Raises:
+    Compilation error if file not found
+
+  Example usage:
+    {% set sql = demo_source_ops._get_sql('baseline/shop_schema') %}
+    {% do run_query(sql) %}
+
+  File structure:
+    data/
+      ├── duckdb/
+      │   ├── baseline/shop_schema.sql
+      │   └── deltas/day_01_shop.sql
+      └── azure/
+          ├── baseline/shop_schema.sql
+          └── deltas/day_01_shop.sql
+#}
+
+{% macro _get_sql(path) %}
+  {# Detect adapter type and select appropriate directory #}
+  {% set adapter_dir = 'duckdb' if target.type == 'duckdb' else 'azure' %}
+  {% set full_path = 'data/' ~ adapter_dir ~ '/' ~ path ~ '.sql' %}
+
+  {# Load SQL file contents #}
+  {% set sql = load_file_contents(full_path) %}
+
+  {# Raise error if file not found #}
+  {% if sql is none %}
+    {{ exceptions.raise_compiler_error(
+      "SQL file not found: " ~ full_path ~
+      " (adapter: " ~ target.type ~ ")"
+    ) }}
+  {% endif %}
+
+  {{ return(sql) }}
+{% endmacro %}

--- a/macros/_internal/_log.sql
+++ b/macros/_internal/_log.sql
@@ -1,0 +1,17 @@
+{#
+  Internal helper macro for consistent logging across operations.
+
+  Wraps dbt's log() function with consistent formatting and ensures
+  messages are always displayed to the user.
+
+  Args:
+    msg (str): Message to log
+
+  Example usage:
+    {{ demo_source_ops._log("Loading baseline data...") }}
+    {{ demo_source_ops._log("✓ Baseline loaded successfully") }}
+#}
+
+{% macro _log(msg) %}
+  {{ log(msg, info=True) }}
+{% endmacro %}


### PR DESCRIPTION
## Summary
Implement three foundational helper macros that all main operations depend on. These enable configuration management, adapter detection, and consistent logging.

## Changes
✅ **`_get_config.sql`** - Configuration management
- Extracts database names from `var('demo_source_ops')`
- Returns dict: `{shop_db: '...', crm_db: '...'}`
- Supports user overrides in dbt_project.yml
- Defaults: `jaffle_shop`, `jaffle_crm`

✅ **`_get_sql.sql`** - Adapter-aware SQL loading
- Detects `target.type` (duckdb vs sqlserver)
- Automatically routes to `data/duckdb/` or `data/azure/`
- Uses `load_file_contents()` to read SQL files
- Raises clear error with adapter context if file not found
- **This is the magic that enables dual-adapter support!**

✅ **`_log.sql`** - Consistent logging
- Simple wrapper for `log(msg, info=True)`
- Ensures all operation messages display to user
- Provides consistent output formatting

## How They Work Together
```sql
{# In a main operation macro: #}
{% set cfg = demo_source_ops._get_config() %}
{{ demo_source_ops._log("Loading " ~ cfg.shop_db ~ "...") }}

{# Automatically loads from data/duckdb/ or data/azure/ #}
{% set sql = demo_source_ops._get_sql('baseline/shop_schema') %}
{% do run_query(sql) %}
```

## Testing
- ✅ Valid Jinja/SQL syntax
- ✅ Macro structure follows dbt conventions
- ⏳ Functional testing awaits SQL files (#8) and main operations (#11-#14)

## Next Steps
After merge:
1. Add DuckDB baseline SQL files (#8)
2. Add DuckDB delta/utility SQL (#9, #10)
3. Implement main operations that use these helpers (#11-#14)

Closes #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)