### PR TITLE
feat(devcontainer): add GitHub-inspired Starship theme

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,6 +13,11 @@ echo "=== Post-create setup starting ==="
 echo "Installing dbt-core and yamllint..."
 pip install --no-cache-dir dbt-core yamllint
 
+# Configure Starship
+echo "Configuring Starship prompt..."
+mkdir -p ~/.config
+cp .devcontainer/starship.toml ~/.config/starship.toml
+
 # Verify installations
 echo ""
 echo "=== Verifying installations ==="

--- a/.devcontainer/starship.toml
+++ b/.devcontainer/starship.toml
@@ -1,0 +1,76 @@
+# Starship configuration - GitHub-inspired theme
+# Optimized for git workflows and clean terminal aesthetics
+
+# Get editor completions based on the config schema
+"$schema" = 'https://starship.rs/config-schema.json'
+
+# Timeout for commands (in milliseconds)
+command_timeout = 500
+
+# Format string
+format = """
+[╭─](bold green) $directory$git_branch$git_status$git_state
+[╰─](bold green)$character"""
+
+# Right-side prompt
+right_format = """$cmd_duration"""
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+vimcmd_symbol = "[❮](bold green)"
+
+[directory]
+style = "bold cyan"
+truncation_length = 3
+truncate_to_repo = true
+format = "[$path]($style)[$read_only]($read_only_style) "
+
+[git_branch]
+symbol = " "
+style = "bold purple"
+format = "on [$symbol$branch(:$remote_branch)]($style) "
+
+[git_status]
+style = "bold yellow"
+format = "([$all_status$ahead_behind]($style) )"
+conflicted = "🏳"
+ahead = "⇡${count}"
+behind = "⇣${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+up_to_date = ""
+untracked = "?${count}"
+stashed = "$${count}"
+modified = "!${count}"
+staged = "+${count}"
+renamed = "»${count}"
+deleted = "✘${count}"
+
+[git_state]
+format = '\([$state( $progress_current/$progress_total)]($style)\) '
+style = "bright-black"
+
+[cmd_duration]
+min_time = 500
+style = "bold yellow"
+format = "[$duration]($style)"
+
+[python]
+symbol = " "
+style = "bold yellow"
+format = '[${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'
+
+[nodejs]
+symbol = " "
+style = "bold green"
+format = '[$symbol($version )]($style)'
+
+[rust]
+symbol = " "
+style = "bold red"
+format = '[$symbol($version )]($style)'
+
+[package]
+symbol = " "
+style = "bold blue"
+format = '[$symbol$version]($style) '


### PR DESCRIPTION
- Add custom Starship configuration with clean GitHub aesthetics
- Configure two-line prompt with directory, git branch, and status
- Show git status indicators (ahead/behind, modified, staged, etc.)
- Display command duration on right side
- Auto-copy config during post-create setup