### PR TITLE
Add DuckDB utility SQL files

### DIFF
--- a/data/duckdb/utilities/truncate_crm.sql
+++ b/data/duckdb/utilities/truncate_crm.sql
@@ -1,0 +1,11 @@
+-- Truncate all jaffle_crm tables
+-- Order matters: delete child tables before parent tables to avoid FK constraint errors
+
+-- Delete email activity first (has FK to campaigns)
+DELETE FROM jaffle_crm.email_activity;
+
+-- Delete web sessions (no FK dependencies)
+DELETE FROM jaffle_crm.web_sessions;
+
+-- Delete campaigns last (was referenced by email_activity)
+DELETE FROM jaffle_crm.campaigns;

--- a/data/duckdb/utilities/truncate_shop.sql
+++ b/data/duckdb/utilities/truncate_shop.sql
@@ -1,0 +1,14 @@
+-- Truncate all jaffle_shop tables
+-- Order matters: delete child tables before parent tables to avoid FK constraint errors
+
+-- Delete order items first (has FKs to orders and products)
+DELETE FROM jaffle_shop.order_items;
+
+-- Delete orders next (has FK to customers)
+DELETE FROM jaffle_shop.orders;
+
+-- Delete products (no dependencies on it anymore)
+DELETE FROM jaffle_shop.products;
+
+-- Delete customers last (no dependencies on it anymore)
+DELETE FROM jaffle_shop.customers;


### PR DESCRIPTION
## Summary
- Created truncate scripts for DuckDB databases to support the demo_reset operation
- Both files use DELETE FROM statements for DuckDB compatibility
- Proper ordering ensures no foreign key constraint violations

## Files Added

### [data/duckdb/utilities/truncate_shop.sql](data/duckdb/utilities/truncate_shop.sql)
Truncates all jaffle_shop tables in the correct order:
1. order_items (child of orders and products)
2. orders (child of customers)
3. products (no dependencies)
4. customers (no dependencies)

### [data/duckdb/utilities/truncate_crm.sql](data/duckdb/utilities/truncate_crm.sql)
Truncates all jaffle_crm tables in the correct order:
1. email_activity (child of campaigns)
2. web_sessions (no dependencies)
3. campaigns (was parent of email_activity)

## Implementation Details
- Uses `DELETE FROM` instead of `TRUNCATE` for broader DuckDB compatibility
- Deletes child tables before parent tables to avoid FK violations
- Comments explain the dependency reasoning
- Ready for integration into demo_reset macro

## Testing
- Syntax validated (standard SQL DELETE statements)
- Ordering verified against schema foreign key constraints
- Will be tested end-to-end when demo_reset macro is implemented

Resolves: #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)