### PR TITLE
feat(macros): implement demo_reset operation

### DIFF
--- a/macros/demo_reset.sql
+++ b/macros/demo_reset.sql
@@ -1,0 +1,65 @@
+{#
+  Resets demo source databases to baseline state.
+
+  Truncates all tables in both jaffle_shop and jaffle_crm databases,
+  then reloads baseline schema and seed data. This is useful for:
+  - Starting fresh after applying deltas
+  - Resetting to known state between demo sessions
+  - Cleaning up after testing
+
+  Usage:
+    dbt run-operation demo_reset --profile demo_source
+
+  Example output:
+    Resetting demo databases to baseline...
+    → Truncating jaffle_shop tables...
+      ✓ Truncated jaffle_shop tables
+    → Truncating jaffle_crm tables...
+      ✓ Truncated jaffle_crm tables
+
+    Loading baseline schema and data...
+    → Creating jaffle_shop tables...
+      ✓ Created jaffle_shop schema
+    → Loading jaffle_shop seed data...
+      ✓ Loaded jaffle_shop seed data
+    → Creating jaffle_crm tables...
+      ✓ Created jaffle_crm schema
+    → Loading jaffle_crm seed data...
+      ✓ Loaded jaffle_crm seed data
+
+    ✓ Baseline load complete!
+
+    ═══ Demo Source Status ═══
+    jaffle_shop:
+      customers: 5 | products: 5 | orders: 5
+      order_items: 5
+
+    jaffle_crm:
+      campaigns: 3 | email_activity: 5
+      web_sessions: 5
+    ══════════════════════════
+#}
+
+{% macro demo_reset() %}
+  {% set cfg = demo_source_ops._get_config() %}
+
+  {{ demo_source_ops._log("") }}
+  {{ demo_source_ops._log("Resetting demo databases to baseline...") }}
+
+  {# Truncate jaffle_shop tables #}
+  {{ demo_source_ops._log("→ Truncating jaffle_shop tables...") }}
+  {% set truncate_shop_sql = demo_source_ops._get_sql('utilities/truncate_shop') %}
+  {% do run_query(truncate_shop_sql) %}
+  {{ demo_source_ops._log("  ✓ Truncated jaffle_shop tables") }}
+
+  {# Truncate jaffle_crm tables #}
+  {{ demo_source_ops._log("→ Truncating jaffle_crm tables...") }}
+  {% set truncate_crm_sql = demo_source_ops._get_sql('utilities/truncate_crm') %}
+  {% do run_query(truncate_crm_sql) %}
+  {{ demo_source_ops._log("  ✓ Truncated jaffle_crm tables") }}
+
+  {{ demo_source_ops._log("") }}
+
+  {# Reload baseline data #}
+  {{ demo_source_ops.demo_load_baseline() }}
+{% endmacro %}


### PR DESCRIPTION
## Summary

Implements the `demo_reset` macro that resets demo source databases to baseline state.

## Changes

- **[macros/demo_reset.sql](macros/demo_reset.sql)** - New operation macro

## How It Works

The `demo_reset` operation performs a complete reset in three steps:

1. **Truncate jaffle_shop** - Deletes all rows from shop tables in FK-safe order
2. **Truncate jaffle_crm** - Deletes all rows from CRM tables in FK-safe order  
3. **Reload baseline** - Calls `demo_load_baseline()` to restore Day 0 state

## Usage

```bash
dbt run-operation demo_reset --profile demo_source
```

## Example Output

```
Resetting demo databases to baseline...
→ Truncating jaffle_shop tables...
  ✓ Truncated jaffle_shop tables
→ Truncating jaffle_crm tables...
  ✓ Truncated jaffle_crm tables


Loading baseline schema and data...
→ Creating jaffle_shop tables...
  ✓ Created jaffle_shop schema
→ Loading jaffle_shop seed data...
  ✓ Loaded jaffle_shop seed data
→ Creating jaffle_crm tables...
  ✓ Created jaffle_crm schema
→ Loading jaffle_crm seed data...
  ✓ Loaded jaffle_crm seed data

✓ Baseline load complete!

═══ Demo Source Status ═══
jaffle_shop:
  customers: 5 | products: 5 | orders: 5
  order_items: 5

jaffle_crm:
  campaigns: 3 | email_activity: 5
  web_sessions: 5
══════════════════════════
```

## Use Cases

- **Reset between demos** - Start fresh for each demo session
- **Clean up after testing** - Remove test deltas and return to baseline
- **Known state recovery** - Quick way to get back to Day 0

## Testing

Tested with DuckDB adapter:
- ✅ Truncation executes without FK constraint errors (correct ordering)
- ✅ Baseline data reloaded successfully
- ✅ Final counts match baseline: 5/5/5/5 (shop), 3/5/5 (CRM)
- ✅ Status display shows correct state after reset

### Test Sequence
```bash
# Start with baseline
dbt run-operation demo_load_baseline --profiles-dir /tmp

# Verify baseline data (5 customers, 5 products)
# ... data exists ...

# Reset to baseline
dbt run-operation demo_reset --profiles-dir /tmp

# Verify reset worked (still 5 customers, 5 products)
# ✓ All counts match baseline
```

## Implementation Details

The macro leverages existing infrastructure:
- Uses `_get_sql('utilities/truncate_shop')` for jaffle_shop truncation
- Uses `_get_sql('utilities/truncate_crm')` for jaffle_crm truncation
- Calls `demo_load_baseline()` for data restoration
- Inherits status display from `demo_load_baseline()`

FK-safe deletion order (from truncate utilities):
- **jaffle_shop**: order_items → orders → products, customers
- **jaffle_crm**: email_activity → web_sessions → campaigns

## Next Steps

- Issue #13: Implement `demo_apply_delta` operation (applies day 1/2/3 changes)
- Future: Add delta tracking to show which deltas have been applied

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)