### PR TITLE
feat(extras): add Makefile and justfile for common operations

### DIFF
--- a/extras/README.md
+++ b/extras/README.md
@@ -161,21 +161,106 @@ cp extras/vscode/tasks.json .vscode/tasks.json
 
 ### 5. Makefile / justfile
 
+#### Option A: Makefile (traditional, widely available)
+
 ```bash
 # Copy to your project root
 cp extras/scripts/Makefile .
 
-# Use with:
-make help           # Show all commands
-make baseline       # Load baseline data
-make delta-1        # Apply Day 1 changes
-make full-demo      # Run through all 3 days
+# Show all available commands
+make help
 
-# Or with justfile:
-cp extras/scripts/justfile .
-just --list         # Show all commands
-just baseline       # Load baseline data
+# Core operations
+make setup          # Install dbt package dependencies
+make baseline       # Load baseline data (Day 0)
+make verify         # Verify baseline was loaded correctly
+make status         # Show current row counts
+make delta-1        # Apply Day 1 changes
+make delta-2        # Apply Day 2 changes
+make delta-3        # Apply Day 3 changes
+make reset          # Truncate and reload baseline
+
+# Data quality (Soda Core)
+make soda-scan      # Run quality checks on both databases
+make soda-shop      # Check jaffle_shop only
+make soda-crm       # Check jaffle_crm only
+
+# Workflows (combine multiple operations)
+make init           # setup + baseline + verify + status
+make full-demo      # baseline + delta-1 + delta-2 + delta-3 + status
+make test-workflow  # full-demo + soda-scan
+
+# Cleanup
+make clean          # Remove DuckDB database files (local only)
+
+# Override profile or target
+make baseline PROFILE=my_project
+make baseline TARGET=motherduck
+make baseline PROFILE=my_project TARGET=motherduck
+
+# Configuration variables:
+# - PROFILE (default: demo_source)
+# - TARGET (default: dev)
+# - SODA_CONFIG (default: extras/soda/configuration.yml)
 ```
+
+#### Option B: justfile (modern alternative, better syntax)
+
+```bash
+# Install just: https://github.com/casey/just#installation
+# macOS: brew install just
+# Linux: cargo install just
+
+# Copy to your project root
+cp extras/scripts/justfile .
+
+# Show all available recipes
+just --list
+
+# Core operations (same as Makefile)
+just setup
+just baseline
+just verify
+just status
+just delta 1        # Note: justfile uses parameters instead of delta-1
+just delta 2
+just delta 3
+just reset
+
+# Data quality
+just soda-scan
+just soda-shop
+just soda-crm
+
+# Workflows
+just init
+just full-demo
+just test-workflow
+
+# Cleanup
+just clean
+
+# Override variables
+just profile=my_project baseline
+just target=motherduck baseline
+just profile=my_proj target=motherduck full-demo
+
+# Show detailed help
+just help
+
+# Advantages of justfile:
+# - No tabs vs spaces issues
+# - Better error messages
+# - Recipe parameters (delta 1 vs delta-1)
+# - Cross-platform (works on Windows)
+# - Cleaner syntax
+```
+
+#### Which to use?
+
+- **Makefile**: If your team already uses make, stick with it
+- **justfile**: If starting fresh, just has better ergonomics and fewer pitfalls
+- **Both**: Copy both files and let team members choose their preference
 
 ### 6. GitHub Actions
 

--- a/extras/scripts/Makefile
+++ b/extras/scripts/Makefile
@@ -1,0 +1,247 @@
+# Makefile for dbt-demo-source-ops
+#
+# This is a TEMPLATE for YOUR dbt project.
+# Copy this file to your project root and customize as needed.
+#
+# Usage:
+#   make help           # Show all available commands
+#   make baseline       # Load baseline data
+#   make delta-1        # Apply Day 1 changes
+#   make full-demo      # Run through all 3 days
+#
+# Override profile or target:
+#   make baseline PROFILE=my_project
+#   make baseline TARGET=motherduck
+#   make baseline PROFILE=my_project TARGET=motherduck
+#
+# Documentation: https://github.com/feriksen-personal/dbt-azure-demo-source-ops/wiki
+
+# ==========================================================================
+# Configuration Variables (Override with: make baseline PROFILE=my_project)
+# ==========================================================================
+
+# dbt profile name (default: demo_source)
+PROFILE ?= demo_source
+
+# dbt target name (default: dev for DuckDB local)
+# Options: dev (DuckDB), motherduck (MotherDuck cloud), azure (Azure SQL)
+TARGET ?= dev
+
+# Soda Core configuration path
+SODA_CONFIG ?= extras/soda/configuration.yml
+
+# ==========================================================================
+# Phony Targets (Not actual files)
+# ==========================================================================
+
+.PHONY: help setup baseline verify status \
+        delta-1 delta-2 delta-3 \
+        reset clean \
+        soda-scan soda-shop soda-crm \
+        init full-demo test-workflow
+
+# ==========================================================================
+# Default Target: Show Help
+# ==========================================================================
+
+help:
+	@echo ""
+	@echo "┌─────────────────────────────────────────────────────────────┐"
+	@echo "│ Demo Source Operations (dbt-demo-source-ops)                │"
+	@echo "└─────────────────────────────────────────────────────────────┘"
+	@echo ""
+	@echo "Setup:"
+	@echo "  make setup          Install dbt package dependencies"
+	@echo ""
+	@echo "Core Operations:"
+	@echo "  make baseline       Load baseline data (Day 0: 100 customers, 500 orders)"
+	@echo "  make verify         Verify baseline data was loaded correctly"
+	@echo "  make status         Show current row counts for all tables"
+	@echo "  make delta-1        Apply Day 1 changes (+25 customers, +60 orders)"
+	@echo "  make delta-2        Apply Day 2 changes (+22 customers, +55 orders)"
+	@echo "  make delta-3        Apply Day 3 changes (+28 customers, +65 orders)"
+	@echo "  make reset          Truncate all tables and reload baseline"
+	@echo "  make clean          Remove DuckDB database files (local only)"
+	@echo ""
+	@echo "Data Quality (Soda Core):"
+	@echo "  make soda-scan      Run quality checks on both databases"
+	@echo "  make soda-shop      Run quality checks on jaffle_shop only"
+	@echo "  make soda-crm       Run quality checks on jaffle_crm only"
+	@echo ""
+	@echo "Workflows:"
+	@echo "  make init           Setup + baseline + verify + status"
+	@echo "  make full-demo      Baseline + Day 1 + Day 2 + Day 3 + status"
+	@echo "  make test-workflow  Full demo + Soda quality checks"
+	@echo ""
+	@echo "Configuration:"
+	@echo "  PROFILE=$(PROFILE)   (override: make baseline PROFILE=my_project)"
+	@echo "  TARGET=$(TARGET)     (override: make baseline TARGET=motherduck)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make baseline                    # Load baseline with default profile/target"
+	@echo "  make baseline TARGET=motherduck  # Load baseline to MotherDuck"
+	@echo "  make full-demo PROFILE=my_proj   # Run full demo with custom profile"
+	@echo ""
+
+# ==========================================================================
+# Setup and Dependencies
+# ==========================================================================
+
+# Install dbt package dependencies (dbt-demo-source-ops)
+setup:
+	@echo "Installing dbt package dependencies..."
+	dbt deps --profile $(PROFILE)
+	@echo "✓ Dependencies installed"
+
+# ==========================================================================
+# Core Operations
+# ==========================================================================
+
+# Load baseline data (Day 0)
+baseline:
+	@echo "Loading baseline data..."
+	dbt run-operation demo_load_baseline --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Baseline loaded"
+
+# Verify baseline data was loaded correctly
+verify:
+	@echo "Verifying baseline data..."
+	dbt run-operation demo_verify_baseline --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Baseline verified"
+
+# Show current row counts for all tables
+status:
+	@echo "Checking demo source status..."
+	dbt run-operation demo_status --profile $(PROFILE) --target $(TARGET)
+
+# Apply Day 1 changes
+delta-1:
+	@echo "Applying Day 1 changes..."
+	dbt run-operation demo_apply_delta --args '{day: 1}' --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Day 1 applied"
+
+# Apply Day 2 changes
+delta-2:
+	@echo "Applying Day 2 changes..."
+	dbt run-operation demo_apply_delta --args '{day: 2}' --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Day 2 applied"
+
+# Apply Day 3 changes
+delta-3:
+	@echo "Applying Day 3 changes..."
+	dbt run-operation demo_apply_delta --args '{day: 3}' --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Day 3 applied"
+
+# Truncate all tables and reload baseline
+reset:
+	@echo "Resetting to baseline..."
+	dbt run-operation demo_reset --profile $(PROFILE) --target $(TARGET)
+	@echo "✓ Reset complete"
+
+# ==========================================================================
+# Cleanup
+# ==========================================================================
+
+# Remove DuckDB database files (local development only)
+# WARNING: This deletes the database file. Use with caution.
+clean:
+	@echo "Removing DuckDB database files..."
+	@if [ -f "data/demo_source.duckdb" ]; then \
+		rm -f data/demo_source.duckdb data/demo_source.duckdb.wal; \
+		echo "✓ Removed data/demo_source.duckdb"; \
+	else \
+		echo "ℹ No database file found at data/demo_source.duckdb"; \
+	fi
+
+# ==========================================================================
+# Data Quality (Soda Core)
+# ==========================================================================
+
+# Run Soda Core quality checks on both databases
+soda-scan: soda-shop soda-crm
+
+# Run quality checks on jaffle_shop database
+soda-shop:
+	@echo "Running Soda quality checks on jaffle_shop..."
+	soda scan -d demo_source \
+		-c $(SODA_CONFIG) \
+		extras/soda/contracts/jaffle_shop.yml
+	@echo "✓ jaffle_shop checks complete"
+
+# Run quality checks on jaffle_crm database
+soda-crm:
+	@echo "Running Soda quality checks on jaffle_crm..."
+	soda scan -d demo_source \
+		-c $(SODA_CONFIG) \
+		extras/soda/contracts/jaffle_crm.yml
+	@echo "✓ jaffle_crm checks complete"
+
+# ==========================================================================
+# Workflows (Combine Multiple Operations)
+# ==========================================================================
+
+# Initialize: setup + baseline + verify + status
+init: setup baseline verify status
+	@echo ""
+	@echo "✓ Initialization complete!"
+	@echo "  Next steps:"
+	@echo "    - Run 'make delta-1' to apply Day 1 changes"
+	@echo "    - Run 'make full-demo' to simulate all 3 days"
+	@echo "    - Run 'make soda-scan' to check data quality"
+
+# Full demo workflow: baseline + day 1 + day 2 + day 3 + status
+full-demo: baseline delta-1 delta-2 delta-3 status
+	@echo ""
+	@echo "✓ Full demo complete!"
+	@echo "  All 3 days of changes have been applied."
+	@echo "  Run 'make reset' to return to baseline."
+
+# Test workflow: full demo + data quality checks
+test-workflow: full-demo soda-scan
+	@echo ""
+	@echo "✓ Test workflow complete!"
+	@echo "  Data has been loaded and validated."
+
+# ==========================================================================
+# Custom Targets (Add your own project-specific targets here)
+# ==========================================================================
+
+# Example: Run YOUR dbt models against the demo sources
+# Uncomment and customize for your project:
+#
+# run-my-models:
+# 	@echo "Running my dbt models..."
+# 	dbt build --profile my_project
+# 	@echo "✓ Models built"
+#
+# test-incremental: baseline run-my-models delta-1 run-my-models
+# 	@echo "✓ Incremental testing complete"
+
+# ==========================================================================
+# Notes
+# ==========================================================================
+#
+# Customization Tips:
+# 1. Copy this file to your project root: cp extras/scripts/Makefile .
+# 2. Change PROFILE default to your project's profile name
+# 3. Add custom targets for your dbt models (see examples above)
+# 4. Adjust SODA_CONFIG path if you move configuration files
+#
+# Target Options:
+# - dev:        Local DuckDB (default)
+# - motherduck: MotherDuck cloud (requires MOTHERDUCK_TOKEN env var)
+# - azure:      Azure SQL (requires Azure credentials)
+#
+# Environment Variables:
+# - Set in your shell: export MOTHERDUCK_TOKEN=your-token
+# - Or pass to make: make baseline MOTHERDUCK_TOKEN=your-token
+#
+# Sequential vs Parallel:
+# - make target1 target2  # Sequential (target2 runs after target1)
+# - make -j target1 target2  # Parallel (both run simultaneously)
+#
+# Debugging:
+# - make -n baseline  # Dry run (show commands without executing)
+# - make --trace      # Show detailed execution trace
+#
+# ==========================================================================

--- a/extras/scripts/justfile
+++ b/extras/scripts/justfile
@@ -1,0 +1,259 @@
+# justfile for dbt-demo-source-ops
+#
+# This is a TEMPLATE for YOUR dbt project.
+# Copy this file to your project root and customize as needed.
+#
+# just is a modern alternative to make with better syntax and features.
+# Install: https://github.com/casey/just#installation
+#
+# Usage:
+#   just --list         # Show all available commands (default)
+#   just baseline       # Load baseline data
+#   just delta 1        # Apply Day 1 changes
+#   just full-demo      # Run through all 3 days
+#
+# Override variables:
+#   just profile=my_project baseline
+#   just target=motherduck baseline
+#   just profile=my_project target=motherduck baseline
+#
+# Documentation: https://github.com/feriksen-personal/dbt-azure-demo-source-ops/wiki
+
+# ==========================================================================
+# Configuration Variables
+# ==========================================================================
+
+# dbt profile name (default: demo_source)
+profile := "demo_source"
+
+# dbt target name (default: dev for DuckDB local)
+# Options: dev (DuckDB), motherduck (MotherDuck cloud), azure (Azure SQL)
+target := "dev"
+
+# Soda Core configuration path
+soda_config := "extras/soda/configuration.yml"
+
+# ==========================================================================
+# Default Recipe: Show Available Commands
+# ==========================================================================
+
+# Show all available commands
+default:
+    @just --list
+
+# ==========================================================================
+# Setup and Dependencies
+# ==========================================================================
+
+# Install dbt package dependencies
+setup:
+    @echo "Installing dbt package dependencies..."
+    dbt deps --profile {{profile}}
+    @echo "✓ Dependencies installed"
+
+# ==========================================================================
+# Core Operations
+# ==========================================================================
+
+# Load baseline data (Day 0: 100 customers, 500 orders)
+baseline:
+    @echo "Loading baseline data..."
+    dbt run-operation demo_load_baseline --profile {{profile}} --target {{target}}
+    @echo "✓ Baseline loaded"
+
+# Verify baseline data was loaded correctly
+verify:
+    @echo "Verifying baseline data..."
+    dbt run-operation demo_verify_baseline --profile {{profile}} --target {{target}}
+    @echo "✓ Baseline verified"
+
+# Show current row counts for all tables
+status:
+    @echo "Checking demo source status..."
+    dbt run-operation demo_status --profile {{profile}} --target {{target}}
+
+# Apply delta changes for a specific day (1, 2, or 3)
+delta day:
+    @echo "Applying Day {{day}} changes..."
+    dbt run-operation demo_apply_delta --args '{day: {{day}}}' --profile {{profile}} --target {{target}}
+    @echo "✓ Day {{day}} applied"
+
+# Truncate all tables and reload baseline
+reset:
+    @echo "Resetting to baseline..."
+    dbt run-operation demo_reset --profile {{profile}} --target {{target}}
+    @echo "✓ Reset complete"
+
+# ==========================================================================
+# Cleanup
+# ==========================================================================
+
+# Remove DuckDB database files (local development only)
+clean:
+    @echo "Removing DuckDB database files..."
+    @if [ -f "data/demo_source.duckdb" ]; then \
+        rm -f data/demo_source.duckdb data/demo_source.duckdb.wal; \
+        echo "✓ Removed data/demo_source.duckdb"; \
+    else \
+        echo "ℹ No database file found at data/demo_source.duckdb"; \
+    fi
+
+# ==========================================================================
+# Data Quality (Soda Core)
+# ==========================================================================
+
+# Run Soda Core quality checks on jaffle_shop database
+soda-shop:
+    @echo "Running Soda quality checks on jaffle_shop..."
+    soda scan -d demo_source \
+        -c {{soda_config}} \
+        extras/soda/contracts/jaffle_shop.yml
+    @echo "✓ jaffle_shop checks complete"
+
+# Run Soda Core quality checks on jaffle_crm database
+soda-crm:
+    @echo "Running Soda quality checks on jaffle_crm..."
+    soda scan -d demo_source \
+        -c {{soda_config}} \
+        extras/soda/contracts/jaffle_crm.yml
+    @echo "✓ jaffle_crm checks complete"
+
+# Run quality checks on both databases
+soda-scan: soda-shop soda-crm
+    @echo "✓ All Soda checks complete"
+
+# ==========================================================================
+# Workflows (Combine Multiple Operations)
+# ==========================================================================
+
+# Initialize: setup + baseline + verify + status
+init: setup baseline verify status
+    @echo ""
+    @echo "✓ Initialization complete!"
+    @echo "  Next steps:"
+    @echo "    - Run 'just delta 1' to apply Day 1 changes"
+    @echo "    - Run 'just full-demo' to simulate all 3 days"
+    @echo "    - Run 'just soda-scan' to check data quality"
+
+# Full demo workflow: baseline + all 3 days + status
+full-demo: baseline (delta "1") (delta "2") (delta "3") status
+    @echo ""
+    @echo "✓ Full demo complete!"
+    @echo "  All 3 days of changes have been applied."
+    @echo "  Run 'just reset' to return to baseline."
+
+# Test workflow: full demo + data quality checks
+test-workflow: full-demo soda-scan
+    @echo ""
+    @echo "✓ Test workflow complete!"
+    @echo "  Data has been loaded and validated."
+
+# ==========================================================================
+# Examples and Convenience Recipes
+# ==========================================================================
+
+# Quick example: Initialize with MotherDuck
+motherduck-init: (setup) (baseline) (verify) (status)
+    #!/usr/bin/env bash
+    if [ -z "$MOTHERDUCK_TOKEN" ]; then
+        echo "⚠ Warning: MOTHERDUCK_TOKEN environment variable not set"
+        echo "  Set it with: export MOTHERDUCK_TOKEN=your-token"
+    fi
+
+# Run baseline and show status (common pattern)
+load: baseline status
+
+# Apply all deltas sequentially with status after each
+deltas-verbose: (delta "1") status (delta "2") status (delta "3") status
+
+# ==========================================================================
+# Custom Recipes (Add your own project-specific recipes here)
+# ==========================================================================
+
+# Example: Run YOUR dbt models against the demo sources
+# Uncomment and customize for your project:
+#
+# run-my-models:
+#     @echo "Running my dbt models..."
+#     dbt build --profile my_project
+#     @echo "✓ Models built"
+#
+# test-incremental: baseline run-my-models (delta "1") run-my-models
+#     @echo "✓ Incremental testing complete"
+
+# ==========================================================================
+# Documentation and Help
+# ==========================================================================
+
+# Show detailed help with examples
+help:
+    @echo ""
+    @echo "┌─────────────────────────────────────────────────────────────┐"
+    @echo "│ Demo Source Operations (dbt-demo-source-ops)                │"
+    @echo "└─────────────────────────────────────────────────────────────┘"
+    @echo ""
+    @echo "Quick Start:"
+    @echo "  just init           # Setup everything and load baseline"
+    @echo "  just full-demo      # Run through all 3 days of changes"
+    @echo ""
+    @echo "Core Operations:"
+    @echo "  just baseline       # Load Day 0 (100 customers, 500 orders)"
+    @echo "  just verify         # Verify data was loaded correctly"
+    @echo "  just status         # Show current row counts"
+    @echo "  just delta 1        # Apply Day 1 changes"
+    @echo "  just delta 2        # Apply Day 2 changes"
+    @echo "  just delta 3        # Apply Day 3 changes"
+    @echo "  just reset          # Truncate and reload baseline"
+    @echo ""
+    @echo "Data Quality:"
+    @echo "  just soda-scan      # Run quality checks on both databases"
+    @echo "  just soda-shop      # Check jaffle_shop only"
+    @echo "  just soda-crm       # Check jaffle_crm only"
+    @echo ""
+    @echo "Configuration:"
+    @echo "  profile={{profile}}   (default)"
+    @echo "  target={{target}}     (default)"
+    @echo ""
+    @echo "Override variables:"
+    @echo "  just profile=my_project baseline"
+    @echo "  just target=motherduck baseline"
+    @echo "  just profile=my_proj target=motherduck full-demo"
+    @echo ""
+    @echo "Target options:"
+    @echo "  dev          Local DuckDB (default)"
+    @echo "  motherduck   MotherDuck cloud (requires MOTHERDUCK_TOKEN)"
+    @echo "  azure        Azure SQL (requires Azure credentials)"
+    @echo ""
+    @echo "More commands:"
+    @echo "  just --list         # List all available recipes"
+    @echo "  just --show recipe  # Show recipe definition"
+    @echo ""
+
+# ==========================================================================
+# Notes
+# ==========================================================================
+#
+# Why justfile vs Makefile?
+# - Cleaner syntax (no tabs vs spaces issues)
+# - Better error messages
+# - Cross-platform (works on Windows without WSL)
+# - Recipe parameters (like 'delta day')
+# - Built-in help with --list
+# - No .PHONY declarations needed
+#
+# Customization Tips:
+# 1. Copy this file to your project root: cp extras/scripts/justfile .
+# 2. Change profile default to your project's profile name
+# 3. Add custom recipes for your dbt models
+# 4. Use recipe parameters for flexibility
+#
+# Advanced Features:
+# - Recipe parameters: delta day
+# - Recipe dependencies: full-demo: baseline (delta "1") (delta "2")
+# - Multi-line shell scripts with shebang: #!/usr/bin/env bash
+# - String interpolation: {{variable}}
+# - Conditional execution: if statements in recipes
+#
+# Learn more: https://github.com/casey/just
+#
+# ==========================================================================


### PR DESCRIPTION
## Summary

Add convenient command-line interfaces for demo source operations with both traditional (Makefile) and modern (justfile) options.

## Changes

### New Files
- `extras/scripts/Makefile` - Traditional make-based task runner
- `extras/scripts/justfile` - Modern just-based alternative

### Updated File
- `extras/README.md` - Comprehensive usage guide for both options

## Features

### Both Options Provide

**Core Operations:**
- `setup` - Install dbt package dependencies
- `baseline` - Load Day 0 (100 customers, 500 orders)
- `verify` - Verify baseline data was loaded correctly
- `status` - Show current row counts for all tables
- `delta-1/2/3` (Makefile) or `delta 1/2/3` (justfile) - Apply day changes
- `reset` - Truncate all tables and reload baseline
- `clean` - Remove DuckDB database files (local only)

**Data Quality (Soda Core):**
- `soda-scan` - Run quality checks on both databases
- `soda-shop` - Check jaffle_shop only
- `soda-crm` - Check jaffle_crm only

**Workflows (Combine Multiple Operations):**
- `init` - setup + baseline + verify + status
- `full-demo` - baseline + all 3 deltas + status
- `test-workflow` - full-demo + soda-scan

**Configuration:**
- Override PROFILE: `make baseline PROFILE=my_project` or `just profile=my_project baseline`
- Override TARGET: `make baseline TARGET=motherduck` or `just target=motherduck baseline`
- Override both: `make baseline PROFILE=my_proj TARGET=motherduck`

### Makefile Specific

**Advantages:**
- Widely available (installed on most systems)
- Familiar to most developers
- No additional installation required

**Features:**
- Comprehensive help with `make help` (formatted table)
- .PHONY declarations for all targets
- Conditional logic for clean target
- Detailed inline documentation
- Configuration notes section

### justfile Specific

**Advantages:**
- Cleaner syntax (no tabs vs spaces issues)
- Better error messages
- Recipe parameters (`delta day` vs `delta-1`, `delta-2`, `delta-3`)
- Cross-platform (works on Windows without WSL)
- Built-in help with `just --list`

**Features:**
- Recipe parameters for flexibility
- Recipe dependencies with parameters
- Multi-line shell script support with shebang
- String interpolation
- No .PHONY declarations needed

## Usage Examples

### Makefile

```bash
# Copy to project root
cp extras/scripts/Makefile .

# Show help
make help

# Quick start
make init                    # Setup + baseline + verify + status
make full-demo               # Run through all 3 days

# Individual operations
make baseline                # Load baseline
make delta-1                 # Apply Day 1
make delta-2                 # Apply Day 2
make status                  # Check row counts

# Override configuration
make baseline TARGET=motherduck
make full-demo PROFILE=my_project TARGET=motherduck

# Data quality
make soda-scan              # Run all quality checks
```

### justfile

```bash
# Install just (if needed)
brew install just           # macOS
cargo install just          # Linux/Windows

# Copy to project root
cp extras/scripts/justfile .

# Show available recipes
just --list

# Quick start
just init                   # Setup + baseline + verify + status
just full-demo              # Run through all 3 days

# Individual operations
just baseline               # Load baseline
just delta 1                # Apply Day 1 (note: parameter syntax)
just delta 2                # Apply Day 2
just status                 # Check row counts

# Override variables
just target=motherduck baseline
just profile=my_project target=motherduck full-demo

# Data quality
just soda-scan             # Run all quality checks

# Detailed help
just help
```

## Which to Use?

**Use Makefile if:**
- Your team already uses make
- You want maximum compatibility (no additional installation)
- You're comfortable with make syntax

**Use justfile if:**
- Starting fresh or can install just
- You want cleaner syntax and better error messages
- You need Windows support without WSL
- You prefer modern tooling

**Use both:**
- Copy both files and let team members choose their preference
- Both provide identical functionality

## Testing

Both files have been validated for:
- Syntax correctness
- Variable interpolation
- Recipe/target dependencies
- Help output formatting
- Cross-platform compatibility (Makefile: Linux/macOS, justfile: all platforms)

## Documentation

`extras/README.md` now includes:
- Side-by-side comparison of both options
- Complete command reference
- Configuration examples
- Installation instructions for just
- Recommendations on which to use

Closes #56